### PR TITLE
👾 adds config for swagger to provide the authorize UI setting

### DIFF
--- a/src/services/users/users.service.ts
+++ b/src/services/users/users.service.ts
@@ -23,7 +23,9 @@ declare module "../../declarations" {
  * @swagger
  * /users:
  *   get:
- *     summary: Retrieve a list of users
+ *     summary: Retrieve list of users
+ *     security:
+ *       - bearerAuth: []
  *     tags: [Users]
  *     responses:
  *       200:

--- a/src/swagger-redoc.ts
+++ b/src/swagger-redoc.ts
@@ -10,6 +10,20 @@ const swaggerDefinition = {
 		description:
 			"This is the OpenAPI docs of this server, you may try out any endpoint from here. You may create a user, then authenticate, to be able to invoke protected endpoints. There is also RedDoc, which is generated from the swagger spec",
 	},
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+    },
+  },
+  security: [
+    {
+      bearerAuth: [],
+    },
+  ],
 };
 
 const options = {


### PR DESCRIPTION
### Motivation and Context

The swagger doc has a try function, to invoke endpoints via its UI. But it won't work for endpoints requiring authenticated users, via JWT token.

it would be convenient to have the setting in place so that we can seat the JWT token to try out any end point.

### Description

- Config swagger spec to have the authorize widget and have it pass the JWT set token on all protected endpoints.

#### Screenshot/showcase:

![swagger-ui](https://github.com/Apply-Creatures/creature-api-boilerplate/assets/1500712/d627ae42-a29e-4147-ac39-8cd1d0c322ab)


### Area of concern


⚠️ it is to note that the endpoint to create users is currently not protected. I kept it that way for convenience so we can test things easily. But at some point we need a mechanism to provision users via admin or an app role only.

